### PR TITLE
Use region identifiers when setting Tax Class artifacts and dependencies

### DIFF
--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceTaxClassServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceTaxClassServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Commerce.Core.Api;
@@ -81,7 +81,7 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
                 if (countryRegionTaxRate.RegionId.HasValue)
                 {
-                    var regionDepUdi = new GuidUdi(UmbracoCommerceConstants.UdiEntityType.Country, countryRegionTaxRate.CountryId);
+                    var regionDepUdi = new GuidUdi(UmbracoCommerceConstants.UdiEntityType.Region, countryRegionTaxRate.RegionId.Value);
                     var regionDep = new UmbracoCommerceArtifactDependency(regionDepUdi);
                     dependencies.Add(regionDep);
 


### PR DESCRIPTION
Fixes #11 by using region identifiers instead of country identifiers when obtaining artifacts.