### PR TITLE
v16: Use server-side entity types for localization keys

### DIFF
--- a/src/Umbraco.Commerce.Deploy/wwwroot/umbraco-commerce-deploy.js
+++ b/src/Umbraco.Commerce.Deploy/wwwroot/umbraco-commerce-deploy.js
@@ -10,10 +10,8 @@ export const onInit = async (host, extensionRegistry) => {
         localizations: {
           // Entity types
           deploy_entityTypes: {
-            "uc:product-attribute": "Umbraco Commerce Product Attribute",
-            "uc:product-attributes": "Umbraco Commerce Product Attributes",
-            "uc:product-attribute-preset": "Umbraco Commerce Product Attribute Preset",
-            "uc:product-attribute-presets": "Umbraco Commerce Product Attribute Presets"
+            "umbraco-commerce-product-attribute": "Umbraco Commerce Product Attribute",
+            "umbraco-commerce-product-attribute-preset": "Umbraco Commerce Product Attribute Preset"
           }
         }
       },


### PR DESCRIPTION
I noticed the user-friendly entity type names weren't shown when you queue product attributes and presets, because Deploy uses the entity type from the server (where the queued items are stored), not the client-side entity types:

![Queue for transfer](https://github.com/user-attachments/assets/7440bfc3-c1e9-4e8b-9c9b-a2921856a1eb)

