### PR TITLE
Hotfix v17.0.1: Add fallback entity lookup by alias/code in deploy connectors

### DIFF
--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceCountryServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceCountryServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -46,6 +46,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
             Guid storeId,
             CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetCountriesAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<CountryReadOnly?> GetExistingEntityAsync(CountryArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetCountryAsync(artifact.StoreUdi.Guid, artifact.Code);
 
         public override Task<CountryArtifact?> GetArtifactAsync(GuidUdi? udi, CountryReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -146,11 +149,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     Country? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await Country.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Code,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Code,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name)
                         .SetCodeAsync(artifact.Code)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceCurrencyServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceCurrencyServiceConnector.cs
@@ -47,6 +47,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
             CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetCurrenciesAsync(storeId).AsAsyncEnumerable();
 
+        public override Task<CurrencyReadOnly?> GetExistingEntityAsync(CurrencyArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetCurrencyAsync(artifact.StoreUdi.Guid, artifact.Code);
+
         public override Task<CurrencyArtifact?> GetArtifactAsync(GuidUdi? udi, CurrencyReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -118,12 +121,12 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     Currency? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await Currency.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Code,
-                        artifact.Name,
-                        artifact.CultureName);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Code,
+                            artifact.Name,
+                            artifact.CultureName);
 
                     await entity.SetNameAsync(artifact.Name)
                         .SetCodeAsync(artifact.Code)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceEmailTemplateServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceEmailTemplateServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +43,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<EmailTemplateReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetEmailTemplatesAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<EmailTemplateReadOnly?> GetExistingEntityAsync(EmailTemplateArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetEmailTemplateAsync(artifact.StoreUdi.Guid, artifact.Alias);
 
         public override Task<EmailTemplateArtifact?> GetArtifactAsync(GuidUdi? udi, EmailTemplateReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -99,11 +102,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     EmailTemplate? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await EmailTemplate.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetCategoryAsync((TemplateCategory)artifact.Category)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceEntityServiceConnectorBase.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceEntityServiceConnectorBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -34,6 +34,15 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public abstract IAsyncEnumerable<TEntity> GetEntitiesAsync(CancellationToken cancellationToken = default);
 
         public abstract Task<TArtifact?> GetArtifactAsync(GuidUdi? udi, TEntity? entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets an existing entity by its identifying properties from the artifact (e.g., alias or code).
+        /// Used as a fallback when the GUID lookup fails during deployment.
+        /// </summary>
+        /// <param name="artifact">The artifact containing identifying properties.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The existing entity if found; otherwise, null.</returns>
+        public abstract Task<TEntity?> GetExistingEntityAsync(TArtifact artifact, CancellationToken cancellationToken = default);
 
         public override Task<TArtifact> GetArtifactAsync(
             TEntity entity,
@@ -153,7 +162,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         {
             EnsureType(artifact.Udi);
 
+            // First try to find by GUID
             TEntity? entity = await GetEntityAsync(artifact.Udi.Guid, cancellationToken).ConfigureAwait(false);
+
+            // Fallback: try to find by alias/code if GUID lookup failed (handles GUID mismatches during upgrades)
+            entity ??= await GetExistingEntityAsync(artifact, cancellationToken).ConfigureAwait(false);
 
             return ArtifactDeployState.Create(artifact, entity, this, ProcessPasses[0]);
         }

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceExportTemplateServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceExportTemplateServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +43,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<ExportTemplateReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetExportTemplatesAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<ExportTemplateReadOnly?> GetExistingEntityAsync(ExportTemplateArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetExportTemplateAsync(artifact.StoreUdi.Guid, artifact.Alias);
 
         public override Task<ExportTemplateArtifact?> GetArtifactAsync(GuidUdi? udi, ExportTemplateReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -95,11 +98,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     ExportTemplate? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await ExportTemplate.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetCategoryAsync((TemplateCategory)artifact.Category)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceLocationServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceLocationServiceConnector.cs
@@ -44,6 +44,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public override IAsyncEnumerable<LocationReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetLocationsAsync(storeId).AsAsyncEnumerable();
 
+        public override Task<LocationReadOnly?> GetExistingEntityAsync(LocationArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetLocationAsync(artifact.StoreUdi.Guid, artifact.Alias);
+
         public override Task<LocationArtifact?> GetArtifactAsync(GuidUdi? udi, LocationReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -97,11 +100,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     Location? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await Location.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetTypeAsync((LocationType)artifact.Type)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceOrderStatusServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceOrderStatusServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +43,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<OrderStatusReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetOrderStatusesAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<OrderStatusReadOnly?> GetExistingEntityAsync(OrderStatusArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetOrderStatusAsync(artifact.StoreUdi.Guid, artifact.Alias);
 
         public override Task<OrderStatusArtifact?> GetArtifactAsync(GuidUdi? udi, OrderStatusReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -91,11 +94,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     OrderStatus? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await OrderStatus.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetColorAsync(artifact.Color)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommercePaymentMethodServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommercePaymentMethodServiceConnector.cs
@@ -47,6 +47,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public override IAsyncEnumerable<PaymentMethodReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetPaymentMethodsAsync(storeId).AsAsyncEnumerable();
 
+        public override Task<PaymentMethodReadOnly?> GetExistingEntityAsync(PaymentMethodArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetPaymentMethodAsync(artifact.StoreUdi.Guid, artifact.Alias);
+
         public override Task<PaymentMethodArtifact?> GetArtifactAsync(GuidUdi? udi, PaymentMethodReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -200,12 +203,12 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     PaymentMethod? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await PaymentMethod.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name,
-                        artifact.PaymentProviderAlias);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name,
+                            artifact.PaymentProviderAlias);
 
                     var settings = artifact.PaymentProviderSettings
                         .Where(x => !StringExtensions.InvariantContains(_settingsAccessor.Settings.PaymentMethods.IgnoreSettings, x.Key)) // Ignore any settings that shouldn't be transferred

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommercePrintTemplateServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommercePrintTemplateServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,6 +44,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<PrintTemplateReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetPrintTemplatesAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<PrintTemplateReadOnly?> GetExistingEntityAsync(PrintTemplateArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetPrintTemplateAsync(artifact.StoreUdi.Guid, artifact.Alias);
 
         public override Task<PrintTemplateArtifact?> GetArtifactAsync(GuidUdi? udi, PrintTemplateReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -93,11 +96,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     PrintTemplate? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await PrintTemplate.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetCategoryAsync((TemplateCategory)artifact.Category)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceProductAttributePresetServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceProductAttributePresetServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Umbraco.Commerce.Core.Api;
 using Umbraco.Commerce.Core.Models;
@@ -46,6 +46,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<ProductAttributePresetReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetProductAttributePresetsAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<ProductAttributePresetReadOnly?> GetExistingEntityAsync(ProductAttributePresetArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetProductAttributePresetAsync(artifact.StoreUdi.Guid, artifact.Alias);
 
         public override async Task<ProductAttributePresetArtifact?> GetArtifactAsync(GuidUdi? udi, ProductAttributePresetReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -118,11 +121,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     ProductAttributePreset? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await ProductAttributePreset.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name);
 
                     await entity.SetAliasAsync(artifact.Alias)
                         .SetNameAsync(artifact.Name)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceProductAttributeServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceProductAttributeServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -46,6 +46,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<ProductAttributeReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetProductAttributesAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<ProductAttributeReadOnly?> GetExistingEntityAsync(ProductAttributeArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetProductAttributeAsync(artifact.StoreUdi.Guid, artifact.Alias);
 
         public override Task<ProductAttributeArtifact?> GetArtifactAsync(GuidUdi? udi, ProductAttributeReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -108,11 +111,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     ProductAttribute? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await ProductAttribute.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name.DefaultValue);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name.DefaultValue);
 
                     await entity.SetAliasAsync(artifact.Alias)
                         .SetNameAsync(new TranslatedValue<string>(artifact.Name.DefaultValue, artifact.Name.Translations))

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceRegionServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceRegionServiceConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +43,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
 
         public override IAsyncEnumerable<RegionReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetRegionsAsync(storeId).AsAsyncEnumerable();
+
+        public override Task<RegionReadOnly?> GetExistingEntityAsync(RegionArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetRegionAsync(artifact.StoreUdi.Guid, artifact.CountryUdi.Guid, artifact.Code);
 
         public override Task<RegionArtifact?> GetArtifactAsync(GuidUdi? udi, RegionReadOnly? entity, CancellationToken cancellationToken = default)
         {
@@ -120,12 +123,12 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.CountryUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Country);
 
                     Region? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await Region.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.CountryUdi.Guid,
-                        artifact.Code,
-                        artifact.Name);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.CountryUdi.Guid,
+                            artifact.Code,
+                            artifact.Name);
 
                     await entity.SetNameAsync(artifact.Name)
                         .SetCodeAsync(artifact.Code)

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceShippingMethodServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceShippingMethodServiceConnector.cs
@@ -52,6 +52,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public override IAsyncEnumerable<ShippingMethodReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetShippingMethodsAsync(storeId).AsAsyncEnumerable();
 
+        public override Task<ShippingMethodReadOnly?> GetExistingEntityAsync(ShippingMethodArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetShippingMethodAsync(artifact.StoreUdi.Guid, artifact.Alias);
+
         public override Task<ShippingMethodArtifact?> GetArtifactAsync(GuidUdi? udi, ShippingMethodReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -216,13 +219,13 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     ShippingMethod? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await ShippingMethod.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name,
-                        artifact.ShippingProviderAlias,
-                        (ShippingCalculationMode)artifact.CalculationMode);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name,
+                            artifact.ShippingProviderAlias,
+                            (ShippingCalculationMode)artifact.CalculationMode);
 
                     var settings = artifact.ShippingProviderSettings
                         .Where(x => !_settingsAccessor.Settings.ShippingMethods.IgnoreSettings.InvariantContains(x.Key)) // Ignore any settings that shouldn't be transfered

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceStoreServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceStoreServiceConnector.cs
@@ -50,6 +50,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public override IAsyncEnumerable<StoreReadOnly> GetEntitiesAsync(CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetStoresAsync().AsAsyncEnumerable();
 
+        public override Task<StoreReadOnly?> GetExistingEntityAsync(StoreArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetStoreAsync(artifact.Alias);
+
         public override Task<StoreArtifact?> GetArtifactAsync(GuidUdi? udi, StoreReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -221,11 +224,11 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.Udi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     Store? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await Store.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.Alias,
-                        artifact.Name,
-                        false);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.Alias,
+                            artifact.Name,
+                            false);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetThemeSettingsAsync(new StoreThemeSettings{

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceTaxCalculationMethodServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceTaxCalculationMethodServiceConnector.cs
@@ -45,6 +45,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public override IAsyncEnumerable<TaxCalculationMethodReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetTaxCalculationMethodsAsync(storeId).AsAsyncEnumerable();
 
+        public override Task<TaxCalculationMethodReadOnly?> GetExistingEntityAsync(TaxCalculationMethodArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetTaxCalculationMethodAsync(artifact.StoreUdi.Guid, artifact.Alias);
+
         public override Task<TaxCalculationMethodArtifact?> GetArtifactAsync(GuidUdi? udi, TaxCalculationMethodReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -97,12 +100,12 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     TaxCalculationMethod? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await TaxCalculationMethod.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name,
-                        artifact.SalesTaxProviderAlias);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name,
+                            artifact.SalesTaxProviderAlias);
 
                     var settings = artifact.SalesTaxProviderSettings
                         .Where(x => !_settingsAccessor.Settings.TaxCalculationMethods.IgnoreSettings.InvariantContains(x.Key)) // Ignore any settings that shouldn't be transferred

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceTaxClassServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceTaxClassServiceConnector.cs
@@ -45,6 +45,9 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
         public override IAsyncEnumerable<TaxClassReadOnly> GetEntitiesAsync(Guid storeId, CancellationToken cancellationToken = default)
             => _umbracoCommerceApi.GetTaxClassesAsync(storeId).AsAsyncEnumerable();
 
+        public override Task<TaxClassReadOnly?> GetExistingEntityAsync(TaxClassArtifact artifact, CancellationToken cancellationToken = default)
+            => _umbracoCommerceApi.GetTaxClassAsync(artifact.StoreUdi.Guid, artifact.Alias);
+
         public override Task<TaxClassArtifact?> GetArtifactAsync(GuidUdi? udi, TaxClassReadOnly? entity, CancellationToken cancellationToken = default)
         {
             if (entity == null)
@@ -129,12 +132,12 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                     artifact.StoreUdi.EnsureType(UmbracoCommerceConstants.UdiEntityType.Store);
 
                     TaxClass? entity = state.Entity != null ? await state.Entity.AsWritableAsync(uow) : await TaxClass.CreateAsync(
-                        uow,
-                        artifact.Udi.Guid,
-                        artifact.StoreUdi.Guid,
-                        artifact.Alias,
-                        artifact.Name,
-                        artifact.DefaultTaxRate);
+                            uow,
+                            artifact.Udi.Guid,
+                            artifact.StoreUdi.Guid,
+                            artifact.Alias,
+                            artifact.Name,
+                            artifact.DefaultTaxRate);
 
                     await entity.SetNameAsync(artifact.Name, artifact.Alias)
                         .SetDefaultTaxRateAsync(artifact.DefaultTaxRate)

--- a/src/Umbraco.Commerce.Deploy/wwwroot/umbraco-package.json
+++ b/src/Umbraco.Commerce.Deploy/wwwroot/umbraco-package.json
@@ -1,7 +1,7 @@
 {
   "id": "Umbraco.Commerce.Deploy",
   "name": "Umbraco Commerce Deploy",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "allowTelemetry": true,
   "extensions": [
     {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This pull request enhances the deployment process for Umbraco Commerce entities by introducing a fallback mechanism to locate entities by their identifying properties (such as alias or code) when GUID lookups fail. This is particularly useful during upgrades or migrations where GUIDs may have changed, ensuring smoother deployments and reducing the risk of missing or duplicated entities. The change is implemented across all relevant service connectors and the abstract base class.