### PR TITLE
Deploy store-level customer settings (17.1.0-rc.1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <GlobalPackageReference Include="Umbraco.JsonSchema.Extensions" Version="0.3.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Commerce.Cms.Startup" Version="[17.0.0, 17.999.999)" />
-    <PackageVersion Include="Umbraco.Commerce.Persistence.Sqlite" Version="[17.0.0, 17.999.999)" />
+    <PackageVersion Include="Umbraco.Commerce.Cms.Startup" Version="[17.2.0-rc.1, 17.999.999)" />
+    <PackageVersion Include="Umbraco.Commerce.Persistence.Sqlite" Version="[17.2.0-rc.1, 17.999.999)" />
     <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[17.0.0, 17.999.999)" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <GlobalPackageReference Include="Umbraco.JsonSchema.Extensions" Version="0.3.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Umbraco.Commerce.Cms.Startup" Version="[17.2.0-rc.1, 17.999.999)" />
-    <PackageVersion Include="Umbraco.Commerce.Persistence.Sqlite" Version="[17.2.0-rc.1, 17.999.999)" />
+    <PackageVersion Include="Umbraco.Commerce.Cms.Startup" Version="[17.2.0, 17.999.999)" />
+    <PackageVersion Include="Umbraco.Commerce.Persistence.Sqlite" Version="[17.2.0, 17.999.999)" />
     <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[17.0.0, 17.999.999)" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Commerce.Deploy/Artifacts/CommunicationPreferenceArtifact.cs
+++ b/src/Umbraco.Commerce.Deploy/Artifacts/CommunicationPreferenceArtifact.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Commerce.Deploy.Artifacts
+{
+    public class CommunicationPreferenceArtifact
+    {
+        public string Name { get; set; }
+
+        public string? Icon { get; set; }
+    }
+}

--- a/src/Umbraco.Commerce.Deploy/Artifacts/StoreArtifact.cs
+++ b/src/Umbraco.Commerce.Deploy/Artifacts/StoreArtifact.cs
@@ -71,6 +71,14 @@ namespace Umbraco.Commerce.Deploy.Artifacts
 
         public IEnumerable<string>?AllowedUserRoles { get; set; }
 
+        public bool CommunicationPreferencesEnabled { get; set; }
+
+        public IEnumerable<CommunicationPreferenceArtifact>? CommunicationPreferences { get; set; }
+
+        public IEnumerable<StoreCustomerPropertyArtifact>? CustomerProperties { get; set; }
+
+        public int CustomerIdType { get; set; }
+
         public int SortOrder { get; set; }
     }
 }

--- a/src/Umbraco.Commerce.Deploy/Artifacts/StoreCustomerPropertyArtifact.cs
+++ b/src/Umbraco.Commerce.Deploy/Artifacts/StoreCustomerPropertyArtifact.cs
@@ -1,0 +1,11 @@
+namespace Umbraco.Commerce.Deploy.Artifacts
+{
+    public class StoreCustomerPropertyArtifact
+    {
+        public string Alias { get; set; }
+
+        public string Value { get; set; }
+
+        public string? Placeholder { get; set; }
+    }
+}

--- a/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceStoreServiceConnector.cs
+++ b/src/Umbraco.Commerce.Deploy/Connectors/ServiceConnectors/UmbracoCommerceStoreServiceConnector.cs
@@ -85,6 +85,14 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                 AbandonedCartLandingPageUrl = entity.AbandonedCartLandingPageUrl,
                 AllowedUsers = entity.AllowedUsers.Select(x => x.UserId).ToList(),
                 AllowedUserRoles = entity.AllowedUserRoles.Select(x => x.Role).ToList(),
+                CommunicationPreferencesEnabled = entity.CommunicationPreferencesEnabled,
+                CommunicationPreferences = entity.CommunicationPreferences
+                    .Select(x => new CommunicationPreferenceArtifact { Name = x.Name, Icon = x.Icon })
+                    .ToList(),
+                CustomerProperties = entity.CustomerProperties
+                    .Select(x => new StoreCustomerPropertyArtifact { Alias = x.Alias, Value = x.Value, Placeholder = x.Placeholder })
+                    .ToList(),
+                CustomerIdType = (int)entity.CustomerIdType,
             };
 
             // Base currency
@@ -250,6 +258,13 @@ namespace Umbraco.Commerce.Deploy.Connectors.ServiceConnectors
                         .SetSortOrderAsync(artifact.SortOrder)
                         .SetAllowedUsersAsync(artifact.AllowedUsers)
                         .SetAllowedUserRolesAsync(artifact.AllowedUserRoles);
+
+                    await entity.SetCommunicationPreferencesEnabledAsync(artifact.CommunicationPreferencesEnabled);
+                    await entity.SetCommunicationPreferencesAsync(artifact.CommunicationPreferences?
+                        .Select(x => new CommunicationPreference(x.Name, x.Icon)));
+                    await entity.SetCustomerPropertiesAsync(artifact.CustomerProperties?
+                        .Select(x => new StoreCustomerProperty(x.Alias, x.Value, x.Placeholder)));
+                    await entity.SetCustomerIdTypeAsync((CustomerIdType)artifact.CustomerIdType);
 
                     if (artifact.CookieTimeout.HasValue)
                     {

--- a/src/Umbraco.Commerce.Deploy/UmbracoCommerceUdiGetterExtensions.cs
+++ b/src/Umbraco.Commerce.Deploy/UmbracoCommerceUdiGetterExtensions.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Commerce.Deploy
                 ShippingMethodReadOnly shippingMethod => shippingMethod.GetUdi(),
                 PaymentMethodReadOnly paymentMethod => paymentMethod.GetUdi(),
                 TaxClassReadOnly taxClass => taxClass.GetUdi(),
+                TaxCalculationMethodReadOnly taxCalculationMethod => taxCalculationMethod.GetUdi(),
                 EmailTemplateReadOnly emailTemplate => emailTemplate.GetUdi(),
                 PrintTemplateReadOnly printTemplate => printTemplate.GetUdi(),
                 ExportTemplateReadOnly exportTemplate => exportTemplate.GetUdi(),
@@ -53,6 +54,9 @@ namespace Umbraco.Commerce.Deploy
 
         public static GuidUdi GetUdi(this TaxClassReadOnly entity)
             => new GuidUdi(UmbracoCommerceConstants.UdiEntityType.TaxClass, entity.Id);
+        
+        public static GuidUdi GetUdi(this TaxCalculationMethodReadOnly entity)
+            => new GuidUdi(UmbracoCommerceConstants.UdiEntityType.TaxCalculationMethod, entity.Id);
 
         public static GuidUdi GetUdi(this EmailTemplateReadOnly entity)
             => new GuidUdi(UmbracoCommerceConstants.UdiEntityType.EmailTemplate, entity.Id);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.1.0-rc.1",
+  "version": "17.1.0",
   "assemblyVersion": {
     "precision": "build"
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.0.1",
+  "version": "17.1.0-rc.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
## Summary
Backport for the 17.x line: adds Deploy support for the **store-level customer settings** introduced by the customer-management feature (Core 17.2.0):

- `CommunicationPreferencesEnabled` (bool)
- `CommunicationPreferences` (list of `{Name, Icon}`)
- `CustomerProperties` — customer property **definitions** (`{Alias, Value, Placeholder}`)
- `CustomerIdType` (enum)

Store *configuration*, deployed between environments like other store settings. Customer/order **data** remains non-deployable user-generated content.

## Changes
- New nested artifacts `CommunicationPreferenceArtifact`, `StoreCustomerPropertyArtifact`
- `StoreArtifact`: 4 new properties
- `UmbracoCommerceStoreServiceConnector`: forward + reverse mapping
- `version.json` → `17.1.0-rc.1` (Deploy's own next minor from 17.0.1)
- Bump `Umbraco.Commerce.Cms.Startup` / `Umbraco.Commerce.Persistence.Sqlite` dependency to `[17.2.0-rc.1, 17.999.999)` (the new store setters ship in Core 17.2.0)

## ⚠️ Build sequencing
References **Core 17.2.0-rc.1**, which must be published first (core-first release ordering). CI will not build green until that Core RC is on the feed. Verified statically against the Core 17.2.0 source; not yet compiled against a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)