### PR TITLE
Add GetUdi method for TaxCalculationMethod

### DIFF
--- a/src/Umbraco.Commerce.Deploy/UmbracoCommerceUdiGetterExtensions.cs
+++ b/src/Umbraco.Commerce.Deploy/UmbracoCommerceUdiGetterExtensions.cs
@@ -17,6 +17,7 @@ namespace Umbraco.Commerce.Deploy
                 ShippingMethodReadOnly shippingMethod => shippingMethod.GetUdi(),
                 PaymentMethodReadOnly paymentMethod => paymentMethod.GetUdi(),
                 TaxClassReadOnly taxClass => taxClass.GetUdi(),
+                TaxCalculationMethodReadOnly taxCalculationMethod => taxCalculationMethod.GetUdi(),
                 EmailTemplateReadOnly emailTemplate => emailTemplate.GetUdi(),
                 PrintTemplateReadOnly printTemplate => printTemplate.GetUdi(),
                 ExportTemplateReadOnly exportTemplate => exportTemplate.GetUdi(),
@@ -53,6 +54,9 @@ namespace Umbraco.Commerce.Deploy
 
         public static GuidUdi GetUdi(this TaxClassReadOnly entity)
             => new GuidUdi(UmbracoCommerceConstants.UdiEntityType.TaxClass, entity.Id);
+        
+        public static GuidUdi GetUdi(this TaxCalculationMethodReadOnly entity)
+            => new GuidUdi(UmbracoCommerceConstants.UdiEntityType.TaxCalculationMethod, entity.Id);
 
         public static GuidUdi GetUdi(this EmailTemplateReadOnly entity)
             => new GuidUdi(UmbracoCommerceConstants.UdiEntityType.EmailTemplate, entity.Id);


### PR DESCRIPTION
any store with a tax calculation method breaks deploy. schema tab + schema compare/transfer both 500.

GetUdi(EntityBase) has no case for TaxCalculationMethodReadOnly -> hits _ => null:
https://github.com/umbraco/Umbraco.Commerce.Deploy/blob/release-17.0.2/src/Umbraco.Commerce.Deploy/UmbracoCommerceUdiGetterExtensions.cs#L27

then GetArtifactsAsync does current.EntityType on that null -> Null reference exception

logging is useless here. bare null reference exception, no commerce frames in stack, no entity type logged -> looks like the null is in umbraco not commerce. took forever to find.

also silent: WriteEntityArtifact gets null udi and noops, so tax calc method never writes a .uda -> never deploys between envs, no warning.

breaks:

deploy schema tab (500)
schema compare / transfer
artifact write on save (silent)
fix = add the missing arm + overload like every other type:

TaxCalculationMethodReadOnly m => m.GetUdi(),

public static GuidUdi GetUdi(this TaxCalculationMethodReadOnly entity)
=> new GuidUdi(UmbracoCommerceConstants.UdiEntityType.TaxCalculationMethod, entity.Id);

Checked the following and all contain bug.
17.0.2
release/17.1.0
17.1.0-rc.1,
support/17.x
18.0.x


Can bypass the null reference exception with this.. but likely just going to mess up your udas

{
  "Umbraco": {
    "Deploy": {
      "Settings": {
        "ExcludedEntityTypes": [ "umbraco-commerce-tax-calculation-method" ]
      }
    }
  }
}